### PR TITLE
Fix typos in some headers of simplify docs

### DIFF
--- a/doc/src/modules/simplify/simplify.rst
+++ b/doc/src/modules/simplify/simplify.rst
@@ -97,7 +97,7 @@ powdenest
 ^^^^^^^^^
 .. autofunction:: powdenest
 
-Combinatrial simplification
+Combinatorial simplification
 ---------------------------
 .. module:: sympy.simplify.combsimp
 
@@ -105,7 +105,7 @@ combsimp
 ^^^^^^^^
 .. autofunction:: combsimp
 
-Square Root Denest
+Square Root Denesting
 ------------------
 .. module:: sympy.simplify.sqrtdenest
 
@@ -113,7 +113,7 @@ sqrtdenest
 ^^^^^^^^^^
 .. autofunction:: sqrtdenest
 
-Common Subexpresion Elimination
+Common Subexpression Elimination
 -------------------------------
 .. module:: sympy.simplify.cse_main
 


### PR DESCRIPTION
Supplied missing letters in "combinatrial" and "subexpresion". Also, "denest" -> "denesting".